### PR TITLE
fix(doc): fix trace key

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -107,7 +107,7 @@ This extension allows you to specify json schemas that you want to validate agai
 
 ## Debug
 
-Add `"yaml.server.trace": "verbose"` to your `coc-settings.json` to get verbose
+Add `"yaml.trace.server": "verbose"` to your `coc-settings.json` to get verbose
 output of LSP communication.
 
 Open output channel by command:


### PR DESCRIPTION
I fixed json key for tracing server based on https://github.com/neoclide/coc-yaml/blob/aca9aae69ecd7f0953ab3353361b4ce9f089dbd8/package.json#L32
