### PR TITLE
Bump Yaml Language Server to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,6 @@
     "webpack-cli": "^3.3.4"
   },
   "dependencies": {
-    "yaml-language-server": "^0.4.0"
+    "yaml-language-server": "^0.7.1"
   }
 }


### PR DESCRIPTION
The current `0.4.0` is very much behind, specially with the Kubernetes completions.