### PR TITLE
Explicit prettier dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "webpack-cli": "^3.3.4"
   },
   "dependencies": {
+    "prettier": "^2.2.0",
     "vscode-json-languageservice": "3.8.4",
     "yaml-language-server": "^0.12.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2472,6 +2472,11 @@ prettier@2.0.5:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
   integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
+prettier@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.0.tgz#8a03c7777883b29b37fb2c4348c66a78e980418b"
+  integrity sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"


### PR DESCRIPTION
Latest version of coc-yaml with new yaml-language-server crashes with `Error: Cannot find module 'prettier'`. Prettier is an optional dependency on yaml-language-server because of openshift internal reasons.
But I suppose for coc-yaml prettier is not optional because it's used for code formatting.

It's important for NixOS ecosystem because node2nix which is widely used in nixpkgs for node packages [doesn't build optional dependencies by default](https://github.com/svanderburg/node2nix/issues/73) (and to fix that just for coc-yaml some not pretty hacks would be required).