### PR TITLE
Bump yaml-lanauge-server 0.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,6 @@
   "dependencies": {
     "prettier": "2.0.5",
     "vscode-json-languageservice": "4.1.0",
-    "yaml-language-server": "0.20.0"
+    "yaml-language-server": "0.22.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,11 +101,6 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-jsonc-parser@^2.2.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.3.1.tgz#59549150b133f2efacca48fe9ce1ec0659af2342"
-  integrity sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==
-
 jsonc-parser@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
@@ -226,13 +221,13 @@ yaml-language-server-parser@0.1.2:
   resolved "https://registry.yarnpkg.com/yaml-language-server-parser/-/yaml-language-server-parser-0.1.2.tgz#8f660b64f1838e7845412341a9d71a5f3b280f6c"
   integrity sha512-GQ2eRE5GcKBK8XVKBIcMyOfC8WMZmEs6gogtVc6knLKE6pG+e5L/lOMfBxZzAt2lqye5itMggQ9+6stXAVhMsw==
 
-yaml-language-server@0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/yaml-language-server/-/yaml-language-server-0.20.0.tgz#5a0ccb8bbb1b398c1586a814ae405d33e20e82e6"
-  integrity sha512-JV5jqB/1p2g4WCW1Gi6Kd3RQQSepdvTQBIDLSSoVzi7Q7kH+6tFkFJlMCBs0qmxLPkaU062d3IxdTWDK/MvvEA==
+yaml-language-server@0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/yaml-language-server/-/yaml-language-server-0.22.0.tgz#f9b8283c838d1f83fb99939bf67d30930a63eb79"
+  integrity sha512-+b2B5qsQhVdovneS3cU8HzTIZSMw8gn6zsznXqtjHYrdXUZqLCnWhnYNVRWLrWSzrxOHOyczOnx60sSuQNctJw==
   dependencies:
     js-yaml "^4.1.0"
-    jsonc-parser "^2.2.1"
+    jsonc-parser "^3.0.0"
     request-light "^0.2.4"
     vscode-json-languageservice "^4.1.0"
     vscode-languageserver "^7.0.0"


### PR DESCRIPTION
Bump Yaml Language Server from 0.20.0 to 0.22.0

See:
- https://github.com/redhat-developer/yaml-language-server/compare/0.20.0...0.22.0
- https://github.com/redhat-developer/yaml-language-server/blob/main/CHANGELOG.md